### PR TITLE
Fix hardcoded "coreos-cluster" name. Pass in CLUSTER_NAME variables. 

### DIFF
--- a/resources/cloud-config/admiral.yaml.tmpl
+++ b/resources/cloud-config/admiral.yaml.tmpl
@@ -6,7 +6,7 @@ coreos:
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
   fleet:
     public-ip: $private_ipv4
-    metadata: "env=CLUSTER-NAME,platform=ec2,provider=aws,role=admiral"
+    metadata: env=${CLUSTER_NAME},platform=ec2,provider=aws,role=admiral
   update:
     reboot-strategy: best-effort
   locksmith:
@@ -212,7 +212,7 @@ write_files:
     content: |
         AWS_ACCOUNT=${AWS_ACCOUNT}
         AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
-        CLUSTER_NAME=coreos-cluster
+        CLUSTER_NAME=${CLUSTER_NAME}
   - path: /root/.aws/envvars
     permissions: 0600
     owner: root

--- a/resources/cloud-config/s3-cloudconfig-bootstrap.sh
+++ b/resources/cloud-config/s3-cloudconfig-bootstrap.sh
@@ -52,7 +52,7 @@ accountId=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/docu
 	| grep -Eo '([[:digit:]]{12})')
 
 # Bucket path for the cloud-config.yaml 
-bucket=${accountId}-coreos-cluster-cloudinit
+bucket=${accountId}-CLUSTER-NAME-cloudinit
 
 # Path to cloud-config.yaml
 # Remove environment from instanceProfile, if any. Assume all instances sharing the same prefix is the same role.
@@ -96,7 +96,7 @@ create_string_to_sign
 signature=$(/bin/echo -n "$stringToSign" | openssl sha1 -hmac ${s3Secret} -binary | base64)
 filePath=${initialCluster}
 debug_log
-retry=4
+retry=5
 ready=0
 until [[ $retry -eq 0 ]]  || [[ $ready -eq 1  ]]
 do

--- a/resources/cloud-config/worker.yaml.tmpl
+++ b/resources/cloud-config/worker.yaml.tmpl
@@ -7,7 +7,7 @@ coreos:
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
   fleet:
     public-ip: $private_ipv4
-    metadata: "env=CLUSTER-NAME,platform=ec2,provider=aws,role=worker"
+    metadata: env=${CLUSTER_NAME},platform=ec2,provider=aws,role=worker
   update:
     reboot-strategy: best-effort
   locksmith:
@@ -151,31 +151,6 @@ write_files:
             done
         fi
         exit 0
-  - path: /opt/bin/update-window.sh
-    permissions: 0700
-    owner: root
-    content: |
-        #!/bin/bash
-        # If etcd is active, this uses locksmith. Otherwise, it randomly delays the reboot.
-        delay=$(/usr/bin/expr $RANDOM % 3600 )
-        rebootflag='NEED_REBOOT'
-        hostip=$(hostname -i | tr -d ' ')
-        ismember=$(etcdctl member list |grep -Eo "(http://$hostip:2380)")
-        
-        if update_engine_client -status | grep $rebootflag;
-        then
-            echo -n "etcd2 is "
-            if systemctl is-active etcd2 && [[ $ismember != "" ]];
-            then
-                echo "Update reboot with locksmithctl."
-                locksmithctl reboot
-            else
-                echo "Update reboot in $delay seconds."
-                sleep $delay
-                reboot
-            fi
-        fi
-        exit 0
   - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
     content: |
         [Service]
@@ -187,7 +162,7 @@ write_files:
     content: |
         AWS_ACCOUNT=${AWS_ACCOUNT}
         AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
-        CLUSTER_NAME=coreos-cluster
+        CLUSTER_NAME=${CLUSTER_NAME}
   - path: /root/.aws/envvars
     permissions: 0600
     owner: root

--- a/resources/terraforms/admiral.tf
+++ b/resources/terraforms/admiral.tf
@@ -46,6 +46,7 @@ resource "template_file" "admiral_cloud_config" {
         "AWS_ACCESS_KEY_ID" = "${aws_iam_access_key.deployment.id}"
         "AWS_SECRET_ACCESS_KEY" = "${aws_iam_access_key.deployment.secret}"
         "AWS_DEFAULT_REGION" = "${var.aws_account.default_region}"
+        "CLUSTER_NAME" = "${var.cluster_name}"
     }
 }
 

--- a/resources/terraforms/etcd.tf
+++ b/resources/terraforms/etcd.tf
@@ -46,6 +46,7 @@ resource "template_file" "etcd_cloud_config" {
         "AWS_ACCESS_KEY_ID" = "${aws_iam_access_key.deployment.id}"
         "AWS_SECRET_ACCESS_KEY" = "${aws_iam_access_key.deployment.secret}"
         "AWS_DEFAULT_REGION" = "${var.aws_account.default_region}"
+        "CLUSTER_NAME" = "${var.cluster_name}"
     }
 }
 

--- a/resources/terraforms/worker.tf
+++ b/resources/terraforms/worker.tf
@@ -5,8 +5,8 @@ module "worker" {
   # a list of subnet IDs to launch resources in.
   cluster_vpc_zone_identifiers = "${module.worker_subnet_a.id},${module.worker_subnet_b.id},${module.worker_subnet_c.id}"
   cluster_min_size = 1
-  cluster_max_size = 2
-  cluster_desired_capacity = 2
+  cluster_max_size = 1
+  cluster_desired_capacity = 1
   cluster_security_groups = "${aws_security_group.worker.id}"
 
   # Instance specifications
@@ -45,6 +45,7 @@ resource "template_file" "worker_cloud_config" {
         "AWS_ACCESS_KEY_ID" = "${aws_iam_access_key.deployment.id}"
         "AWS_SECRET_ACCESS_KEY" = "${aws_iam_access_key.deployment.secret}"
         "AWS_DEFAULT_REGION" = "${var.aws_account.default_region}"
+        "CLUSTER_NAME" = "${var.cluster_name}"
     }
 }
 


### PR DESCRIPTION
- resources/cloud-config/*.yaml.tmpl: pass in CLUSTER_NAME variable, instead of hardcode "coreos-cluster".
- resources/cloud-config/s3-cloudconfig-bootstrap.sh: also need to replace CLUSTER-NAME for bucket name.
- resources/terraform/{admiral,worker,etcd.tf: pass CLUSTER_NAME to cloud-config yaml template.
