### PR TITLE
advertise_addr was renamed to redirect_addr in 0.6.1

### DIFF
--- a/resources/cloud-config/files-vault.yaml
+++ b/resources/cloud-config/files-vault.yaml
@@ -5,7 +5,7 @@
     content: |
       backend "etcd" {
         address = "http://127.0.0.1:2379"
-        advertise_addr = "https://$public_ipv4:8200"
+        redirect_addr = "https://$public_ipv4:8200"
         path = "vault"
         sync = "yes"
       }

--- a/resources/cloud-config/vault.yaml.tmpl
+++ b/resources/cloud-config/vault.yaml.tmpl
@@ -170,7 +170,7 @@ write_files:
     content: |
       backend "etcd" {
         address = "http://127.0.0.1:2379"
-        advertise_addr = "https://$public_ipv4:8200"
+        redirect_addr = "https://$public_ipv4:8200"
         path = "vault"
         sync = "yes"
       }


### PR DESCRIPTION
The field advertise_addr was renamed to redirect_addr starting with
vault 0.6.1 - The changes I did reflect this change